### PR TITLE
Fixed export to be named, like other utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/javascript-utilities",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "JavaScript utilities.",
   "main": "lib/index.js",
   "author": "Baltimore County Developers",

--- a/src/Urls.js
+++ b/src/Urls.js
@@ -11,4 +11,4 @@ const GetParameterByName = parameterName => {
     : decodeURIComponent(results[1].replace(/\+/g, " "));
 };
 
-export default GetParameterByName;
+export { GetParameterByName };


### PR DESCRIPTION
Exported `GetParameterByName` as default instead of named export.